### PR TITLE
Use redis manager in views.

### DIFF
--- a/vxpolls/content/views.py
+++ b/vxpolls/content/views.py
@@ -1,14 +1,12 @@
-import redis
-import yaml
-
 from django.shortcuts import render, redirect
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from vxpolls.content import forms
 from vxpolls.manager import PollManager
+from vumi.persist.redis_manager import RedisManager
 
 
-redis = redis.Redis(**settings.VXPOLLS_REDIS_CONFIG)
+redis = RedisManager.from_config(settings.VXPOLLS_REDIS_CONFIG)
 
 
 def show(request, poll_id):

--- a/vxpolls/djdashboard/views.py
+++ b/vxpolls/djdashboard/views.py
@@ -1,14 +1,12 @@
+import json
 from django.shortcuts import render, Http404
 from django.http import HttpResponse
 from django.conf import settings
-import json
-import redis
+from vumi.persist.redis_manager import RedisManager
 
 from vxpolls.manager import PollManager
 
-
-vxpolls_redis_config = settings.VXPOLLS_REDIS_CONFIG
-redis = redis.Redis(**vxpolls_redis_config)
+redis = RedisManager.from_config(settings.VXPOLLS_REDIS_CONFIG)
 
 poll_manager = PollManager(redis, settings.VXPOLLS_PREFIX)
 


### PR DESCRIPTION
Currently views directly construct a global redis object at import time. They should construct a redis manager instead (this sould allow redis to be stubbed out in tests).
