### PR TITLE
first message not accepted as valid input for question

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -83,7 +83,7 @@ class PollDashboardTestCase(TestCase):
             participant.set_poll_id(self.poll_id)
             question = self.poll.get_next_question(participant)
             self.poll.set_last_question(participant, question)
-            error_message = self.poll.submit_answer(participant, answer)
+            error_message = yield self.poll.submit_answer(participant, answer)
             if error_message:
                 raise ValueError(error_message)
             yield self.poll_manager.save_participant(self.poll_id, participant)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -40,26 +40,29 @@ class PollManagerTestCase(TestCase):
     def tearDown(self):
         yield self.poll_manager.stop()
 
+    @inlineCallbacks
     def test_invalid_input_response(self):
         expected_question = 'What is your favorite colour?'
         invalid_input = 'I LOVE TURTLES!!'
         question = self.poll.get_next_question(self.participant)
         self.poll.set_last_question(self.participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = self.poll.submit_answer(self.participant,
+        response = yield self.poll.submit_answer(self.participant,
                                                     invalid_input)
         self.assertEqual(response, expected_question)
 
+    @inlineCallbacks
     def test_valid_input_response(self):
         expected_question = 'What is your favorite colour?'
         valid_input = 'red'
         question = self.poll.get_next_question(self.participant)
         self.poll.set_last_question(self.participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = self.poll.submit_answer(self.participant,
+        response = yield self.poll.submit_answer(self.participant,
                                                     valid_input)
         self.assertEqual(None, response)
 
+    @inlineCallbacks
     def test_iterating(self):
         for index, question in enumerate(self.default_questions):
             valid_input = random.choice(question['valid_responses'])
@@ -71,7 +74,7 @@ class PollManagerTestCase(TestCase):
                                                 self.participant)
             self.poll.set_last_question(self.participant,
                                                 next_question)
-            self.poll.submit_answer(self.participant,
+            yield self.poll.submit_answer(self.participant,
                                                 valid_input)
             if not index:
                 self.assertEqual(None, last_question)
@@ -92,7 +95,7 @@ class PollManagerTestCase(TestCase):
         question = poll.get_next_question(participant)
         poll.set_last_question(participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = poll.submit_answer(participant, valid_input)
+        response = yield poll.submit_answer(participant, valid_input)
         self.assertEqual(None, response)
 
     @inlineCallbacks
@@ -109,7 +112,7 @@ class PollManagerTestCase(TestCase):
         question = poll.get_next_question(participant)
         poll.set_last_question(participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = poll.submit_answer(participant, valid_input)
+        response = yield poll.submit_answer(participant, valid_input)
         # original question should be repeated
         self.assertEqual(expected_question, response)
 
@@ -155,6 +158,7 @@ class MultiLevelPollManagerTestCase(TestCase):
     def tearDown(self):
         yield self.poll_manager.stop()
 
+    @inlineCallbacks
     def test_checks_skip(self):
         expected_question = 'What is your favorite colour?'
         valid_input = 'red'
@@ -163,7 +167,7 @@ class MultiLevelPollManagerTestCase(TestCase):
         self.assertEqual(question.valid_responses, ['red', 'green', 'blue'])
         self.poll.set_last_question(self.participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = self.poll.submit_answer(self.participant,
+        response = yield self.poll.submit_answer(self.participant,
                                                     valid_input)
         self.assertEqual(None, response)
 
@@ -171,6 +175,7 @@ class MultiLevelPollManagerTestCase(TestCase):
         next_question = self.poll.get_next_question(self.participant)
         self.assertEqual(next_question.copy, next_question_copy)
 
+    @inlineCallbacks
     def test_checks_follow_up(self):
         expected_question = 'What is your favorite colour?'
         valid_input = 'green'
@@ -179,7 +184,7 @@ class MultiLevelPollManagerTestCase(TestCase):
         self.assertEqual(question.valid_responses, ['red', 'green', 'blue'])
         self.poll.set_last_question(self.participant, question)
         self.assertEqual(question.copy, expected_question)
-        response = self.poll.submit_answer(self.participant,
+        response = yield self.poll.submit_answer(self.participant,
                                                     valid_input)
         self.assertEqual(None, response)
 
@@ -187,7 +192,7 @@ class MultiLevelPollManagerTestCase(TestCase):
         next_question = self.poll.get_next_question(self.participant)
         self.poll.set_last_question(self.participant, next_question)
         self.assertEqual(next_question.copy, next_question_copy)
-        response = self.poll.submit_answer(self.participant, 'dark')
+        response = yield self.poll.submit_answer(self.participant, 'dark')
         self.assertEqual(None, response)
 
         next_question_copy = 'Orange, Yellow or Black?'

--- a/vxpolls/example.py
+++ b/vxpolls/example.py
@@ -3,7 +3,7 @@
 import hashlib
 import json
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.application.base import ApplicationWorker
@@ -57,34 +57,48 @@ class PollApplication(ApplicationWorker):
         participant.questions_per_session = poll.batch_size
 
         # If we have an unanswered question then we always need to reply
-        # as its a resuming session.
+        # as it's a resuming session.
         if participant.has_unanswered_question:
-            self.on_message(participant, poll, message)
+            yield self.on_message(participant, poll, message)
         else:
             # If we have more questions for the participant, continue otherwise
             # end the session
             if poll.has_more_questions_for(participant):
                 next_question = poll.get_next_question(participant)
-                participant.has_unanswered_question = True
                 poll.set_last_question(participant, next_question)
-                yield self.pm.save_participant(poll.poll_id, participant)
-                self.on_message(participant, poll, message)
+                yield self.on_message(participant, poll, message)
             else:
-                self.end_session(participant, poll, message)
+                participant.has_unanswered_question = False
+                yield self.end_session(participant, poll, message)
 
+        yield self.pm.save_participant(poll.poll_id, participant)
+
+    @inlineCallbacks
     def on_message(self, participant, poll, message):
-        # receive a message as part of a live session
         content = message['content']
-        error_message = poll.submit_answer(participant, content)
-        if error_message:
-            self.reply_to(message, error_message)
+        # Only validate input if the last question asked actually
+        # had something to validate against.
+        last_question = poll.get_last_question(participant)
+        if last_question and last_question.valid_responses:
+            error_message = yield poll.submit_answer(participant, content)
+            if error_message:
+                yield self.reply_to(message, error_message)
+                return
+        elif last_question:
+            reply = yield maybeDeferred(self.ask_question, participant, poll,
+                last_question)
+            yield self.reply_to(message, reply)
+            return
+
+        if poll.has_more_questions_for(participant):
+            question = poll.get_next_question(participant)
+            reply = yield maybeDeferred(self.ask_question, participant, poll,
+                question)
+            participant.has_unanswered_question = False
+            yield self.reply_to(message, reply)
         else:
-            if poll.has_more_questions_for(participant):
-                next_question = poll.get_next_question(participant)
-                reply = self.ask_question(participant, poll, next_question)
-                self.reply_to(message, reply)
-            else:
-                self.end_session(participant, poll, message)
+            participant.has_unanswered_question = False
+            yield self.end_session(participant, poll, message)
 
     @inlineCallbacks
     def end_session(self, participant, poll, message):
@@ -96,14 +110,12 @@ class PollApplication(ApplicationWorker):
             response = config.get('batch_completed_response',
                                     self.batch_completed_response)
             yield self.reply_to(message, response, continue_session=False)
-            yield self.pm.save_participant(poll.poll_id, participant)
         else:
             response = config.get('survey_completed_response',
                                     self.survey_completed_response)
             yield self.reply_to(message, response, continue_session=False)
             participant.poll_id = None
             participant.set_poll_uid(None)
-            yield self.pm.save_participant(poll.poll_id, participant)
             if poll.repeatable:
                 # Archive for demo purposes so we can redial in and start over.
                 yield self.pm.archive(poll.poll_id, participant)
@@ -114,8 +126,8 @@ class PollApplication(ApplicationWorker):
         # the incoming message
         if poll.has_more_questions_for(participant):
             next_question = poll.get_next_question(participant)
-            question_copy = yield self.ask_question(participant, poll,
-                next_question)
+            question_copy = yield maybeDeferred(self.ask_question, participant,
+                poll, next_question)
             yield self.reply_to(message, question_copy)
         else:
             yield self.end_session(participant, poll, message)
@@ -123,5 +135,4 @@ class PollApplication(ApplicationWorker):
     def ask_question(self, participant, poll, question):
         participant.has_unanswered_question = True
         poll.set_last_question(participant, question)
-        self.pm.save_participant(poll.poll_id, participant)
         return question.copy

--- a/vxpolls/multipoll_example.py
+++ b/vxpolls/multipoll_example.py
@@ -117,7 +117,7 @@ class MultiPollApplication(PollApplication):
     def on_message(self, participant, poll, message):
         # receive a message as part of a live session
         content = message['content']
-        error_message = poll.submit_answer(participant, content,
+        error_message = yield poll.submit_answer(participant, content,
                                             self.custom_answer_logic)
         if error_message:
             yield self.reply_to(message, error_message)


### PR DESCRIPTION
if 'yes' is one of the valid options for the first question and it is submitted as the first message sent in, it is ignored and the first question is repeated. This is wrong behaviour.
