### PR TITLE
import and export scripts broken after switching to redis managers

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,25 +6,21 @@ from vxpolls.tools.exporter import PollExporter
 from vxpolls.tools.importer import PollImporter
 from vxpolls.manager import PollManager
 
-from vumi.persist.redis_manager import RedisManager
-
 
 class ExportTestCase(TestCase):
 
     def setUp(self):
-        self.r_server = RedisManager.from_config({
-            'FAKE_REDIS': 'yes'
-            })
         self.poll_prefix = 'poll_prefix'
-        self.patch(PollExporter, 'get_redis',
-            lambda *a: self.r_server)
         self.exporter = PollExporter({
             'vxpolls': {
                 'prefix': self.poll_prefix,
+            },
+            'redis_manager': {
+                'FAKE_REDIS': 'yes',
             }
         })
         self.exporter.stdout = StringIO()
-        self.manager = PollManager(self.r_server, self.poll_prefix)
+        self.manager = PollManager(self.exporter.r_server, self.poll_prefix)
 
     def create_poll(self, poll_id, config):
         self.manager.set(poll_id, config)
@@ -52,18 +48,16 @@ class ExportTestCase(TestCase):
 class ImportTestCase(TestCase):
 
     def setUp(self):
-        self.r_server = RedisManager.from_config({
-            'FAKE_REDIS': 'yes'
-            })
         self.poll_prefix = 'poll_prefix'
-        self.patch(PollImporter, 'get_redis',
-            lambda *a: self.r_server)
         self.importer = PollImporter({
             'vxpolls': {
                 'prefix': self.poll_prefix,
+            },
+            'redis_manager': {
+                'FAKE_REDIS': 'yes'
             }
         })
-        self.manager = PollManager(self.r_server, self.poll_prefix)
+        self.manager = PollManager(self.importer.r_server, self.poll_prefix)
         self.config = {
             'batch_size': None,
             'questions': [{

--- a/vxpolls/tools/exporter.py
+++ b/vxpolls/tools/exporter.py
@@ -1,8 +1,11 @@
 # -*- test-case-name: tests.test_tools -*-
 import sys
 import yaml
-import redis
+
+from vumi.persist.redis_manager import RedisManager
+
 from vxpolls.manager import PollManager
+
 from twisted.python import usage
 
 
@@ -11,14 +14,11 @@ class PollExporter(object):
     stdout = sys.stdout
 
     def __init__(self, config):
-        r_config = config.get('redis', {})
+        r_config = config.get('redis_manager', {})
         vxp_config = config.get('vxpolls', {})
         poll_prefix = vxp_config.get('prefix', 'poll_manager')
-        self.r_server = self.get_redis(r_config)
+        self.r_server = self.manager = RedisManager.from_config(r_config)
         self.pm = PollManager(self.r_server, poll_prefix)
-
-    def get_redis(self, config):
-        return redis.Redis(**config)
 
     def get_poll_config(self, poll_id):
         uid = self.pm.get_latest_uid(poll_id)

--- a/vxpolls/tools/importer.py
+++ b/vxpolls/tools/importer.py
@@ -1,22 +1,22 @@
 # -*- test-case-name: tests.test_tools -*-
 import sys
 import yaml
-import redis
+
+from vumi.persist.redis_manager import RedisManager
+
 from vxpolls.manager import PollManager
+
 from twisted.python import usage
 
 
 class PollImporter(object):
 
     def __init__(self, config):
-        r_config = config.get('redis', {})
+        r_config = config.get('redis_manager', {})
         vxp_config = config.get('vxpolls', {})
         poll_prefix = vxp_config.get('prefix', 'poll_manager')
-        self.r_server = self.get_redis(r_config)
+        self.r_server = self.manager = RedisManager.from_config(r_config)
         self.pm = PollManager(self.r_server, poll_prefix)
-
-    def get_redis(self, config):
-        return redis.Redis(**config)
 
     def import_config(self, poll_id, config, force=False):
         if poll_id in self.pm.polls() and not force:


### PR DESCRIPTION
They don't specify a `self.manager` and as a result the @Manager.calls_manager decorator breaks
