### PR TITLE
Feature/vumigo 162 the session manager is not using the prefixes when used by vxpolls

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -40,11 +40,17 @@ class PollManagerTestCase(TestCase):
     def tearDown(self):
         yield self.poll_manager.stop()
 
+    @inlineCallbacks
     def test_session_key_prefixes(self):
         expected_redis_key_prefix = "%s" % (self.poll_manager.r_prefix)
         actual_redis_key_prefix = \
                     self.poll_manager.session_manager.redis.get_key_prefix()
         self.assertEqual(actual_redis_key_prefix, expected_redis_key_prefix)
+        yield self.poll_manager.session_manager.create_session(
+                                                "dummy_test_session")
+        keys = yield self.r_server._client.keys("*dummy_test_session")
+        self.assertEqual("%s:session:dummy_test_session" % (
+                                        self.poll_manager.r_prefix), keys[0])
 
     @inlineCallbacks
     def test_invalid_input_response(self):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -40,6 +40,12 @@ class PollManagerTestCase(TestCase):
     def tearDown(self):
         yield self.poll_manager.stop()
 
+    def test_session_key_prefixes(self):
+        expected_redis_key_prefix = "%s:session" % (self.poll_manager.r_prefix)
+        actual_redis_key_prefix = \
+                        self.poll_manager.session_manager.redis._key_prefix
+        self.assertEqual(actual_redis_key_prefix, expected_redis_key_prefix)
+
     @inlineCallbacks
     def test_invalid_input_response(self):
         expected_question = 'What is your favorite colour?'

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -41,7 +41,7 @@ class PollManagerTestCase(TestCase):
         yield self.poll_manager.stop()
 
     def test_session_key_prefixes(self):
-        expected_redis_key_prefix = "%s:session" % (self.poll_manager.r_prefix)
+        expected_redis_key_prefix = "%s" % (self.poll_manager.r_prefix)
         actual_redis_key_prefix = \
                     self.poll_manager.session_manager.redis.get_key_prefix()
         self.assertEqual(actual_redis_key_prefix, expected_redis_key_prefix)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -43,7 +43,7 @@ class PollManagerTestCase(TestCase):
     def test_session_key_prefixes(self):
         expected_redis_key_prefix = "%s:session" % (self.poll_manager.r_prefix)
         actual_redis_key_prefix = \
-                        self.poll_manager.session_manager.redis._key_prefix
+                    self.poll_manager.session_manager.redis.get_key_prefix()
         self.assertEqual(actual_redis_key_prefix, expected_redis_key_prefix)
 
     @inlineCallbacks

--- a/vxpolls/manager.py
+++ b/vxpolls/manager.py
@@ -18,7 +18,7 @@ class PollManager(object):
         # create a manager attribute so the @calls_manager works
         self.r_server = self.manager = r_server
         self.r_prefix = r_prefix
-        self.sr_server = self.r_server.sub_manager(self.r_key('session'))
+        self.sr_server = self.r_server.sub_manager(self.r_key())
         self.session_manager = SessionManager(self.sr_server)
 
     def r_key(self, *args):

--- a/vxpolls/manager.py
+++ b/vxpolls/manager.py
@@ -18,7 +18,8 @@ class PollManager(object):
         # create a manager attribute so the @calls_manager works
         self.r_server = self.manager = r_server
         self.r_prefix = r_prefix
-        self.session_manager = SessionManager(self.r_server)
+        self.sr_server = self.r_server.sub_manager(self.r_key('session'))
+        self.session_manager = SessionManager(self.sr_server)
 
     def r_key(self, *args):
         parts = [self.r_prefix]


### PR DESCRIPTION
just needed a sub_manager to restore the prefix that used to be passed to the session manager
