### PR TITLE
Poll is not txredis-safe

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,13 +6,13 @@ from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web.client import getPage
 
+from vumi.tests.utils import PersistenceMixin
+
 from vxpolls.manager import PollManager
 from vxpolls.dashboard import PollDashboardServer
 
-from vumi.persist.txredis_manager import TxRedisManager
 
-
-class PollDashboardTestCase(TestCase):
+class PollDashboardTestCase(PersistenceMixin, TestCase):
 
     poll_id = 'poll-id'
     questions = [{
@@ -30,10 +30,9 @@ class PollDashboardTestCase(TestCase):
 
     @inlineCallbacks
     def setUp(self):
-        self.r_server = yield TxRedisManager.from_config({
-            'FAKE_REDIS': 'yes',
-        })
-        self.poll_manager = PollManager(self.r_server)
+        yield self._persist_setUp()
+        self.redis = yield self.get_redis_manager()
+        self.poll_manager = PollManager(self.redis)
         self.poll = yield self.poll_manager.register(self.poll_id, {
             'questions': self.questions,
         })
@@ -44,7 +43,8 @@ class PollDashboardTestCase(TestCase):
         # let the results manager know of the questions available and
         # what it is tracking results for.
         for entry in self.questions:
-            yield self.results_manager.register_question(self.poll_id, entry['copy'],
+            yield self.results_manager.register_question(
+                self.poll_id, entry['copy'],
                 [resp.lower() for resp in entry['valid_responses']])
 
         self.service = PollDashboardServer(self.poll_manager,
@@ -62,6 +62,7 @@ class PollDashboardTestCase(TestCase):
     def tearDown(self):
         yield self.poll_manager.stop()
         yield self.service.stopService()
+        yield self._persist_tearDown()
 
     @inlineCallbacks
     def get_route_json(self, route, **kwargs):
@@ -131,12 +132,12 @@ class PollDashboardTestCase(TestCase):
 
     @inlineCallbacks
     def test_results_csv(self):
-        data = yield self.get_route_csv('results.csv?%s' % (urllib.urlencode({
+        yield self.get_route_csv('results.csv?%s' % (urllib.urlencode({
             'collection_id': self.poll_id,
         }),))
 
     @inlineCallbacks
     def test_users_csv(self):
-        data = yield self.get_route_csv('users.csv?%s' % (urllib.urlencode({
+        yield self.get_route_csv('users.csv?%s' % (urllib.urlencode({
             'collection_id': self.poll_id,
         }),))

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -42,11 +42,15 @@ class BasePollApplicationTestCase(ApplicationTestCase):
             'questions': self.default_questions,
             'transport_name': self.transport_name,
             'batch_size': 2,
-            'redis_manager': {
-                'FAKE_REDIS': 'yes',
-            }
         }
         self.app = yield self.get_application(self.config)
+
+    @inlineCallbacks
+    def get_application(self, *args, **kw):
+        app = yield super(BasePollApplicationTestCase, self).get_application(
+            *args, **kw)
+        self._persist_redis_managers.append(app.redis)
+        returnValue(app)
 
     def get_poll(self, poll_id, participant):
         return self.app.pm.get_poll_for_participant(poll_id, participant)
@@ -213,7 +217,7 @@ class PollApplicationTestCase(BasePollApplicationTestCase):
         self.assertFalse(poll.repeatable)
         participant.has_unanswered_question = True
         participant.set_last_question_index(2)
-        self.app.pm.save_participant(poll_id, participant)
+        yield self.app.pm.save_participant(poll_id, participant)
         # send to the app
         yield self.dispatch(msg)
         [response] = self.get_dispatched_messages()
@@ -246,7 +250,7 @@ class PollApplicationTestCase(BasePollApplicationTestCase):
         self.assertTrue(poll.repeatable)
         participant.has_unanswered_question = True
         participant.set_last_question_index(2)
-        self.app.pm.save_participant(poll_id, participant)
+        yield self.app.pm.save_participant(poll_id, participant)
         # send to the app
         yield self.dispatch(msg)
         [response] = self.get_dispatched_messages()
@@ -359,6 +363,13 @@ class VxpollsRegressionsTestCase(ApplicationTestCase):
         msg = super(VxpollsRegressionsTestCase, self).mkmsg_in(**kwargs)
         msg['helper_metadata']['poll_id'] = self.poll_id
         return msg
+
+    @inlineCallbacks
+    def get_application(self, *args, **kw):
+        app = yield super(VxpollsRegressionsTestCase, self).get_application(
+            *args, **kw)
+        self._persist_redis_managers.append(app.redis)
+        returnValue(app)
 
     @inlineCallbacks
     def get_participant_and_poll(self, user_id, poll_id=None):

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,3 +1,4 @@
+import time
 import yaml
 
 from twisted.internet.defer import inlineCallbacks, returnValue
@@ -434,6 +435,9 @@ class PollManagerVersioningTestCase(BasePollApplicationTestCase):
 
     @inlineCallbacks
     def test_first_question(self):
+        # Sleep 10 ms so the new poll can't accidentally get the same timestamp
+        # as the one it's replacing.
+        time.sleep(0.01)
         # update the poll with new content
         yield self.app.pm.register(self.poll_id, {
             'questions': self.updated_questions

--- a/tests/test_multipoll_example.py
+++ b/tests/test_multipoll_example.py
@@ -1,10 +1,9 @@
 import json
 from datetime import date, timedelta
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.application.tests.test_base import ApplicationTestCase
-from vumi.tests.utils import FakeRedis
 
 from vxpolls.multipoll_example import MultiPollApplication
 
@@ -12,8 +11,6 @@ from vxpolls.multipoll_example import MultiPollApplication
 class BaseMultiPollApplicationTestCase(ApplicationTestCase):
 
     application_class = MultiPollApplication
-
-    timeout = 2
 
     @inlineCallbacks
     def setUp(self):
@@ -26,6 +23,14 @@ class BaseMultiPollApplicationTestCase(ApplicationTestCase):
             'is_demo': True,
         }
         self.app = yield self.get_application(self.config)
+
+    @inlineCallbacks
+    def get_application(self, *args, **kw):
+        app = yield super(
+            BaseMultiPollApplicationTestCase, self).get_application(
+            *args, **kw)
+        self._persist_redis_managers.append(app.redis)
+        returnValue(app)
 
     def get_poll(self, poll_id, participant):
         return self.app.pm.get_poll_for_participant(poll_id, participant)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,32 +2,37 @@ import yaml
 from StringIO import StringIO
 
 from twisted.trial.unittest import TestCase
+from twisted.internet.defer import inlineCallbacks
+
+from vumi.tests.utils import PersistenceMixin
+
 from vxpolls.tools.exporter import PollExporter
 from vxpolls.tools.importer import PollImporter
 from vxpolls.manager import PollManager
 
 
-class ExportTestCase(TestCase):
+class ExportTestCase(PersistenceMixin, TestCase):
 
+    @inlineCallbacks
     def setUp(self):
+        yield self._persist_setUp()
         self.poll_prefix = 'poll_prefix'
-        self.exporter = PollExporter({
+        self.exporter = PollExporter(self.mk_config({
             'vxpolls': {
                 'prefix': self.poll_prefix,
             },
-            'redis_manager': {
-                'FAKE_REDIS': 'yes',
-            }
-        })
+        }))
         self.exporter.stdout = StringIO()
         self.manager = PollManager(self.exporter.r_server, self.poll_prefix)
 
     def create_poll(self, poll_id, config):
         self.manager.set(poll_id, config)
 
+    @inlineCallbacks
     def tearDown(self):
-        self.exporter.pm.stop()
-        self.manager.stop()
+        yield self.exporter.pm.stop()
+        yield self.manager.stop()
+        yield self._persist_tearDown()
 
     def test_export(self):
         config = {
@@ -45,18 +50,17 @@ class ExportTestCase(TestCase):
         self.assertEqual(exported_string, yaml.safe_dump(config))
 
 
-class ImportTestCase(TestCase):
+class ImportTestCase(PersistenceMixin, TestCase):
 
+    @inlineCallbacks
     def setUp(self):
+        yield self._persist_setUp()
         self.poll_prefix = 'poll_prefix'
-        self.importer = PollImporter({
+        self.importer = PollImporter(self.mk_config({
             'vxpolls': {
                 'prefix': self.poll_prefix,
             },
-            'redis_manager': {
-                'FAKE_REDIS': 'yes'
-            }
-        })
+        }))
         self.manager = PollManager(self.importer.r_server, self.poll_prefix)
         self.config = {
             'batch_size': None,
@@ -68,9 +72,11 @@ class ImportTestCase(TestCase):
             'transport_name': 'vxpolls_transport'
         }
 
+    @inlineCallbacks
     def tearDown(self):
-        self.importer.pm.stop()
-        self.manager.stop()
+        yield self.importer.pm.stop()
+        yield self.manager.stop()
+        yield self._persist_tearDown()
 
     def test_import(self):
         self.assertEqual(self.manager.polls(), set([]))

--- a/vxpolls/example.py
+++ b/vxpolls/example.py
@@ -42,7 +42,7 @@ class PollApplication(ApplicationWorker):
             })
 
     def teardown_application(self):
-        self.pm.stop()
+        return self.pm.stop()
 
     @inlineCallbacks
     def consume_user_message(self, message):
@@ -89,7 +89,6 @@ class PollApplication(ApplicationWorker):
                 yield self.reply_to(message, reply)
             else:
                 yield self.end_session(participant, poll, message)
-
 
     @inlineCallbacks
     def end_session(self, participant, poll, message):

--- a/vxpolls/example.py
+++ b/vxpolls/example.py
@@ -3,7 +3,7 @@
 import hashlib
 import json
 
-from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
+from twisted.internet.defer import inlineCallbacks, maybeDeferred
 
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.application.base import ApplicationWorker
@@ -32,8 +32,8 @@ class PollApplication(ApplicationWorker):
 
     @inlineCallbacks
     def setup_application(self):
-        self.r_server = yield TxRedisManager.from_config(self.r_config)
-        self.pm = PollManager(self.r_server, self.poll_prefix)
+        self.redis = yield TxRedisManager.from_config(self.r_config)
+        self.pm = PollManager(self.redis, self.poll_prefix)
         exists = yield self.pm.exists(self.poll_id)
         if not exists:
             yield self.pm.register(self.poll_id, {

--- a/vxpolls/manager.py
+++ b/vxpolls/manager.py
@@ -49,7 +49,8 @@ class PollManager(object):
 
     @Manager.calls_manager
     def register(self, poll_id, version):
-        poll = yield self.get(poll_id, uid=self.set(poll_id, version))
+        uid = yield self.set(poll_id, version)
+        poll = yield self.get(poll_id, uid=uid)
         returnValue(poll)
 
     @Manager.calls_manager
@@ -87,7 +88,8 @@ class PollManager(object):
         if version:
             repeatable = version.get('repeatable', True)
             case_sensitive = version.get('case_sensitive', True)
-            poll = Poll(self.r_server, poll_id, uid, version['questions'],
+            poll = yield Poll.mkpoll(
+                self.r_server, poll_id, uid, version['questions'],
                 version.get('batch_size'), r_prefix=self.r_key('poll'),
                 repeatable=repeatable, case_sensitive=case_sensitive)
             returnValue(poll)
@@ -181,7 +183,7 @@ class PollManager(object):
         returnValue(archives)
 
     def stop(self):
-        self.session_manager.stop()
+        return self.session_manager.stop(stop_redis=False)
 
 
 class Poll(object):
@@ -200,12 +202,23 @@ class Poll(object):
         # before hand.
         self.results_manager = ResultManager(self.r_server,
                                                 self.r_key('results'))
-        self.results_manager.register_collection(self.poll_id)
+        self._setup_d = self._setup_results()
+
+    @Manager.calls_manager
+    def _setup_results(self):
+        yield self.results_manager.register_collection(self.poll_id)
         for index, question_data in enumerate(self.questions):
+            question_data = dict((k.encode('utf8'), v)
+                                 for k, v in question_data.items())
             question = PollQuestion(index, case_sensitive=self.case_sensitive,
-                                        **question_data)
-            self.results_manager.register_question(self.poll_id,
+                                    **question_data)
+            yield self.results_manager.register_question(self.poll_id,
                 question.label_or_copy(), question.valid_responses)
+        returnValue(self)
+
+    @classmethod
+    def mkpoll(cls, *args, **kw):
+        return cls(*args, **kw)._setup_d
 
     def r_key(self, *args):
         parts = [self.r_prefix]
@@ -309,8 +322,10 @@ class Poll(object):
 
     def get_question(self, index):
         if self.has_question(index):
+            questions = dict((k.encode('utf8'), v)
+                             for k, v in self.questions[index].items())
             return PollQuestion(index, case_sensitive=self.case_sensitive,
-                **self.questions[index])
+                **questions)
         return None
 
 

--- a/vxpolls/manager.py
+++ b/vxpolls/manager.py
@@ -36,8 +36,9 @@ class PollManager(object):
 
     @Manager.calls_manager
     def set(self, poll_id, version):
-        # NOTE: This behaves badly if two versions of a poll are created within
-        # an interval shorter than time.time()'s resolution.
+        # NOTE: If two versions of a poll are created within an interval
+        # shorter than time.time()'s resolution, they'll both get the same
+        # score and we won't know which is newer.
         uid = self.generate_unique_id(version)
         yield self.r_server.sadd(self.r_key('polls'), poll_id)
         yield self.r_server.hset(self.r_key('versions', poll_id), uid,

--- a/vxpolls/multipoll_example.py
+++ b/vxpolls/multipoll_example.py
@@ -41,8 +41,8 @@ class MultiPollApplication(PollApplication):
 
     @inlineCallbacks
     def setup_application(self):
-        self.r_server = yield TxRedisManager.from_config(self.r_config)
-        self.pm = PollManager(self.r_server, self.poll_prefix)
+        self.redis = yield TxRedisManager.from_config(self.r_config)
+        self.pm = PollManager(self.redis, self.poll_prefix)
         for poll_id in self.poll_id_list:
             exists = yield self.pm.exists(poll_id)
             if not exists:
@@ -59,10 +59,6 @@ class MultiPollApplication(PollApplication):
         while True:
             yield "%s%s" % (poll_id_prefix, num)
             num = num + 1
-
-    @classmethod
-    def get_first_poll_id(cls, poll_id_prefix):
-        return "%s%s" % (poll_id_prefix, 0)
 
     @classmethod
     def get_first_poll_id(cls, poll_id_prefix):
@@ -111,7 +107,7 @@ class MultiPollApplication(PollApplication):
         if participant.has_unanswered_question:
             yield self.on_message(participant, poll, message)
         else:
-            self.init_session(participant, poll, message)
+            yield self.init_session(participant, poll, message)
 
     @inlineCallbacks
     def on_message(self, participant, poll, message):


### PR DESCRIPTION
`Poll.__init__()` calls `ResultsManager.register_collection()` (and `.register_question()`) in its constructor. This leaves dangling deferreds and results in sadness when we're using txredis.
