### PR TITLE
Unicode vs UTF-8 mismatch when answers are submitted.

### DIFF
--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -322,8 +322,7 @@ class PollResultsTestCase(ApplicationTestCase):
         user_id = '27761234567'
         question = u'Hi, welcome to the Star Menu test system. We’d ' \
                    u'like you to answer a few questions for us. Please ' \
-                   u'tell us your first name. Enter it now. is an ' \
-                   u'unknown question.'
+                   u'tell us your first name.'
 
         with self.manager.defaults(collection_id, user_id) as m:
             yield m.register_question(question)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -320,6 +320,8 @@ class PollResultsTestCase(ApplicationTestCase):
     def test_unicode_questions(self):
         collection_id = 'unique-id'
         user_id = '27761234567'
+        # NOTE: copy taken from a failing production scenario, please not the
+        #       "curly quote" in `We'd`.
         question = u'Hi, welcome to the Star Menu test system. We’d ' \
                    u'like you to answer a few questions for us. Please ' \
                    u'tell us your first name.'

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from twisted.internet.defer import inlineCallbacks
 
 from vumi.application.tests.test_base import ApplicationTestCase
@@ -313,3 +315,20 @@ class PollResultsTestCase(ApplicationTestCase):
             "27761234567,%s" % (utf8_str,),
             ""
             ]))
+
+    @inlineCallbacks
+    def test_unicode_questions(self):
+        collection_id = 'unique-id'
+        user_id = '27761234567'
+        question = u'Hi, welcome to the Star Menu test system. We’d ' \
+                   u'like you to answer a few questions for us. Please ' \
+                   u'tell us your first name. Enter it now. is an ' \
+                   u'unknown question.'
+
+        with self.manager.defaults(collection_id, user_id) as m:
+            yield m.register_question(question)
+
+        # This would've blown up before
+        yield m.add_result(question, 'foo')
+        [stored_question] = yield m.get_questions()
+        self.assertEqual(stored_question, question)


### PR DESCRIPTION
We allow questions to be stored as unicode, the redis client converts these to utf-8 bytestrings before putting them on the wire, however we do not turn them back into unicode strings on retrieval which is making an `in` lookup fail.
