### PR TITLE
Fix CSV export that includes old questions

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -214,6 +214,18 @@ class PollManagerTestCase(PersistenceMixin, TestCase):
         self.assertTrue(csv_data.split('\r\n')[1].startswith(
             'user-1,%s' % (datetime.now().date(),)))
 
+    @inlineCallbacks
+    def test_export_user_data_as_csv_with_old_questions(self):
+        poll = yield self.mkpoll_for_export()
+        # remove some questions from the poll
+        del poll.questions[1:]
+        csv_data = yield self.poll_manager.export_user_data_as_csv(
+            poll, include_old_questions=True)
+        self.assertEqual(csv_data.split('\r\n')[0],
+            'user_id,user_timestamp,question-0,question-1,question-2')
+        self.assertTrue(csv_data.split('\r\n')[1].startswith(
+            'user-1,%s' % (datetime.now().date(),)))
+
 
 class MultiLevelPollManagerTestCase(PersistenceMixin, TestCase):
 

--- a/vxpolls/manager.py
+++ b/vxpolls/manager.py
@@ -255,7 +255,14 @@ class PollManager(object):
         field_names = ['user_id']
         if include_timestamp:
             field_names.append('user_timestamp')
-        field_names.extend([q['label'].encode('utf-8')
+        if include_old_questions:
+            old_questions = set()
+            for user_id, user_data in users:
+                old_questions.update(user_data.iterkeys())
+            old_questions.discard('user_timestamp')
+            field_names.extend(sorted(old_questions))
+        else:
+            field_names.extend([q['label'].encode('utf-8')
                                 for q in poll.questions])
         writer = csv.DictWriter(sio, fieldnames=field_names)
         # write header row


### PR DESCRIPTION
Currently the correct set of field names is not passed to `csv.DictWriter` so it complains when it sees an unexpected question.
